### PR TITLE
fix(calibration): attribute error while using np.float

### DIFF
--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -276,8 +276,8 @@ class CalibrationEngine:
         """
 
         w, h = self.sensor_size
-        u = np.arange(0, w, 20).astype(np.float)
-        v = np.arange(0, h, 20).astype(np.float)
+        u = np.arange(0, w, 20).astype(float)
+        v = np.arange(0, h, 20).astype(float)
         u, v = np.meshgrid(u, v)
         uv_points = np.vstack((u.flatten(), v.flatten())).T
 


### PR DESCRIPTION
Fix AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.