### PR TITLE
Minor improvements

### DIFF
--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -73,7 +73,7 @@ class CalibrationEngine:
 
         logger.info("Start corners extraction")
 
-        for img_f in tqdm(sorted(images_path)):
+        for img_f in tqdm(images_path):
             img = cv.imread(str(img_f))
             height, width = img.shape[:2]
             ratio = width / height

--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -134,6 +134,12 @@ class CalibrationEngine:
         valid_pattern, d_center, min_rms, extrinsics_t, taylor_t = get_first_linear_estimate(self.detections,
                                                                                              self.sensor_size,
                                                                                              grid_size)
+        
+        # the linear estimation can fail, when the images are not good enough
+        if valid_pattern == None or not any(valid_pattern):
+            loader.stop()
+            logger.error("Linear estimation failed of parameters failed. Check the chessboard detection in the supplied calibartion images!")
+            raise ValueError("Linear estimation failed of parameters failed.")
 
         taylor_coefficient, extrinsics_t = get_taylor_linear(self.detections, valid_pattern, extrinsics_t, d_center)
         loader.stop()

--- a/src/pyocamcalib/modelling/utils.py
+++ b/src/pyocamcalib/modelling/utils.py
@@ -26,7 +26,7 @@ from threading import Thread
 from time import sleep
 import numpy as np
 
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.PNG']
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', '.PNG']
 
 
 def transform(extrinsics: np.array, world_points: np.array):
@@ -64,7 +64,7 @@ def get_files(path):
     all_files = []
     for ext in IMG_EXTENSIONS:
         all_files.extend(list(path.glob("*" + ext)))
-    return all_files
+    return sorted(all_files)
 
 
 def generate_checkerboard_points(board_size: Tuple[int, int], square_size: float = 1, z_axis: bool = False):
@@ -152,7 +152,7 @@ def check_detection(corners, image):
     write_text(image_draw, text_1)
     for corner in corners:
         cv.drawMarker(image_draw, tuple(corner.astype(int)), (0, 255, 0))
-    cv.namedWindow("image", 2)
+    cv.namedWindow("image", cv.WINDOW_NORMAL)
     cv.imshow('image', image_draw)
     params = [image_draw, mode_draw, mode_select, corners, idx, new_corners, wait]
     cv.setMouseCallback('image', click_event, params)


### PR DESCRIPTION
Proposed changes:

- Allow using `*.tiff` (not only `*.tif`) images, Pillow supports them
- Image paths were sorted only before being used in the corner detection, breaking the connection between the order of processed images and the order they are written in to the result JSON. (Probably the sorting before iterating over the `data` variables in different parts of the code can be removed.)
- When no valid pattern was detected by the linear estimation, numpy would show a RuntimeWarning that the mean of an empty slice was calculated, which was a hint for the following problem:
- When no valid pattern was detected by the linear estimation, the code for `get_taylor_linear()` would crash, because it's `valid: List[bool]` argument was in fact `None`. This was fixed with a check if the linear estimation was successful, and in case it was not an error is logged prompting the user to check the input images and the program now raises a ValueError