### PR TITLE
Corner detection with adaptive window size

### DIFF
--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -21,13 +21,14 @@ import json
 import pickle
 from itertools import product
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Union
 import cv2 as cv
 import numpy as np
 from datetime import datetime
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 from loguru import logger
+from scipy.spatial.distance import cdist
 
 from pyocamcalib.core._utils import get_reprojection_error_all, get_reprojection_error
 from pyocamcalib.core.linear_estimation import get_first_linear_estimate, get_taylor_linear
@@ -66,7 +67,7 @@ class CalibrationEngine:
         self.cam_name = camera_name
         self.inverse_poly = None
 
-    def detect_corners(self, check: bool = False, max_height: int = 520):
+    def detect_corners(self, check: bool = False, window_size: Union[str, int] = "adaptive", max_height: int = 520):
         images_path = get_files(self.working_dir)
         count = 0
         world_points = generate_checkerboard_points(self.chessboard_size, self.square_size, z_axis=True)
@@ -97,11 +98,29 @@ class CalibrationEngine:
                     corners = np.squeeze(corners)
                     corners[:, 0] *= r_w
                     corners[:, 1] *= r_h
-                    win_size = (5, 5)
+                    
+                    if window_size == "adaptive":
+                        # calculate distance between all corners, returns a len(corners) x len(corners) matrix
+                        pairwise_distances = cdist(corners, corners, 'euclidean')
+                        
+                        # keep only _one_ distance for each pair of corners, and discard distances between a corner and itself
+                        # which means taking only the upper triangular part of the matrix
+                        pairwise_distances = pairwise_distances[np.triu_indices(pairwise_distances.shape[0], k=1)]
+                    
+                        # the minimum distance between any two corners should give us a good estimate of the window size
+                        distance_min = np.min(pairwise_distances)
+                        
+                        # then we use half the minimum distance as the window size
+                        # also the window size must be an integer, so the we truncate it towards zero
+                        win_size = max(int(distance_min / 2), 5)
+                    else:
+                        win_size = window_size
+                        
                     zero_zone = (-1, -1)
                     criteria = (cv.TERM_CRITERIA_EPS + cv.TermCriteria_COUNT, 40, 0.001)
                     corners = np.expand_dims(corners, axis=0)
-                    cv.cornerSubPix(gray, corners, win_size, zero_zone, criteria)
+                    cv.cornerSubPix(gray, corners, (win_size, win_size), zero_zone, criteria)
+                    
                     if check:
                         check_detection(np.squeeze(corners), img)
                     count += 1

--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -73,7 +73,7 @@ class CalibrationEngine:
 
         logger.info("Start corners extraction")
 
-        for img_f in tqdm(sorted(images_path)):
+        for img_f in tqdm(images_path):
             img = cv.imread(str(img_f))
             height, width = img.shape[:2]
             ratio = width / height

--- a/src/pyocamcalib/modelling/calibration.py
+++ b/src/pyocamcalib/modelling/calibration.py
@@ -134,6 +134,12 @@ class CalibrationEngine:
         valid_pattern, d_center, min_rms, extrinsics_t, taylor_t = get_first_linear_estimate(self.detections,
                                                                                              self.sensor_size,
                                                                                              grid_size)
+        
+        # the linear estimation can fail, when the images are not good enough
+        if valid_pattern == None or not any(valid_pattern):
+            loader.stop()
+            logger.error("Linear estimation failed of parameters failed. Check the chessboard detection in the supplied calibartion images!")
+            raise ValueError("Linear estimation failed of parameters failed.")
 
         taylor_coefficient, extrinsics_t = get_taylor_linear(self.detections, valid_pattern, extrinsics_t, d_center)
         loader.stop()

--- a/src/pyocamcalib/modelling/utils.py
+++ b/src/pyocamcalib/modelling/utils.py
@@ -26,7 +26,7 @@ from threading import Thread
 from time import sleep
 import numpy as np
 
-IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.PNG']
+IMG_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif', '.tiff', '.PNG']
 
 
 def transform(extrinsics: np.array, world_points: np.array):
@@ -64,7 +64,7 @@ def get_files(path):
     all_files = []
     for ext in IMG_EXTENSIONS:
         all_files.extend(list(path.glob("*" + ext)))
-    return all_files
+    return sorted(all_files)
 
 
 def generate_checkerboard_points(board_size: Tuple[int, int], square_size: float = 1, z_axis: bool = False):
@@ -152,7 +152,7 @@ def check_detection(corners, image):
     write_text(image_draw, text_1)
     for corner in corners:
         cv.drawMarker(image_draw, tuple(corner.astype(int)), (0, 255, 0))
-    cv.namedWindow("image", 2)
+    cv.namedWindow("image", cv.WINDOW_NORMAL)
     cv.imshow('image', image_draw)
     params = [image_draw, mode_draw, mode_select, corners, idx, new_corners, wait]
     cv.setMouseCallback('image', click_event, params)


### PR DESCRIPTION
As detailed in Issue #6, I'm suggesting an improvement for calibration by allowing an adaptive window size for the initial corner detection with OpenCV. Please refer to the Issue #6 for the details.

Minor fixes from pull request #7 are also included with the remaining three commits. If those are unwanted we can kick them from this pull request.